### PR TITLE
Update import path of github_flavored_markdown package.

### DIFF
--- a/mdhtml/mdtohtml.go
+++ b/mdhtml/mdtohtml.go
@@ -8,7 +8,7 @@ import (
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/qanx/gopress/customcss"
 	"github.com/russross/blackfriday"
-	"github.com/shurcooL/go/github_flavored_markdown"
+	"github.com/shurcooL/github_flavored_markdown"
 )
 
 func separateSlides(inputHTML string) string {


### PR DESCRIPTION
It has moved out into a standalone repo recently. See https://github.com/shurcooL/go/issues/19#issuecomment-102574426 for rationale.
